### PR TITLE
Remove internal manifest from PsfLauncher

### DIFF
--- a/CentennialFixups.sln
+++ b/CentennialFixups.sln
@@ -32,6 +32,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FEAB7FE0-E02D-4276-AEF8-BF6E8F48B55D}"
 	ProjectSection(SolutionItems) = preProject
 		MetadataSchema.xsd = MetadataSchema.xsd
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DynamicLibraryFixup", "fixups\DynamicLibraryFixup\DynamicLibraryFixup.vcxproj", "{40F9058D-8059-4ED4-859E-7A548A73CA4F}"

--- a/CommonSrc/psf_logging.cpp
+++ b/CommonSrc/psf_logging.cpp
@@ -129,11 +129,11 @@ void LogString(DWORD inst, const char* name, const char* value)
 {
     if ((value != NULL && value[1] != 0x0))
     {
-        Log(L"[%d]%s=%s\n", inst, name, value);
+        Log(L"[%d] %s=%s\n", inst, name, value);
     }
     else
     {
-        Log(L"[%d]%s=%ls", inst, name, (wchar_t*)value);
+        Log(L"[%d] %s=%ls", inst, name, (wchar_t*)value);
     }
 }
 
@@ -141,33 +141,33 @@ void LogString(DWORD inst, const char* name, const wchar_t* value)
 {
     if ((value != NULL && ((char*)value)[1] == 0x0))
     {
-        Log(L"[%d]%s=%ls\n", inst, name, value);
+        Log(L"[%d] %s=%ls\n", inst, name, value);
     }
     else
     {
-        Log(L"[%d]%s=%s", inst, name, (char*)value);
+        Log(L"[%d] %s=%s", inst, name, (char*)value);
     }
 }
 
 void LogStringAA(DWORD inst, const char* name, const char* value)
 {
-    Log(L"[%d]%s=%s\n", inst, name, value);
+    Log(L"[%d] %s=%s\n", inst, name, value);
 
 }
 void LogStringAW(DWORD inst, const char* name, const wchar_t* value)
 {
-    Log(L"[%d]%s=%ls", inst, name, value);
+    Log(L"[%d] %s=%ls", inst, name, value);
 }
 
 void LogString(DWORD inst, const wchar_t* name, const char* value)
 {
     if ((value != NULL && value[1] != 0x0))
     {
-        Log(L"[%d]%ls=%ls\n", inst, name, widen(value).c_str());
+        Log(L"[%d] %ls=%ls\n", inst, name, widen(value).c_str());
     }
     else
     {
-        Log(L"[%d]%ls=%ls", inst, name, (wchar_t*)value);
+        Log(L"[%d] %ls=%ls", inst, name, (wchar_t*)value);
     }
 }
 
@@ -175,21 +175,46 @@ void LogString(DWORD inst, const wchar_t* name, const wchar_t* value)
 {
     if ((value != NULL && ((char*)value)[1] == 0x0))
     {
-        Log(L"[%d]%ls=%ls\n", inst, name, value);
+        Log(L"[%d] %ls=%ls\n", inst, name, value);
     }
     else
     {
-        Log(L"[%d]%ls=%ls", inst, name, widen((const char*)value).c_str());
+        Log(L"[%d] %ls=%ls", inst, name, widen((const char*)value).c_str());
     }
 }
 
 void LogStringWA(DWORD inst, const wchar_t* name, const char* value)
 {
-    Log(L"[%d]%ls=%ls\n", inst, name, widen(value).c_str());
+    Log(L"[%d] %ls=%ls\n", inst, name, widen(value).c_str());
 }
 void LogStringWW(DWORD inst, const wchar_t* name, const wchar_t* value)
 {
-    Log(L"[%d]%ls=%ls", inst, name, value);
+    Log(L"[%d] %ls=%ls", inst, name, value);
+}
+
+
+void LogString(DWORD rememberedInst, DWORD inst, const wchar_t* name, const char* value)
+{
+    if ((value != NULL && value[1] != 0x0))
+    {
+        Log(L"[%d][%d] %ls=%ls\n", rememberedInst, inst, name, widen(value).c_str());
+    }
+    else
+    {
+        Log(L"[%d][%d] %ls=%ls", rememberedInst, inst, name, (wchar_t*)value);
+    }
+}
+
+void LogString(DWORD rememberedInst, DWORD inst, const wchar_t* name, const wchar_t* value)
+{
+    if ((value != NULL && ((char*)value)[1] == 0x0))
+    {
+        Log(L"[%d][%d] %ls=%ls\n", rememberedInst, inst, name, value);
+    }
+    else
+    {
+        Log(L"[%d][%d] %ls=%ls", rememberedInst, inst, name, widen((const char*)value).c_str());
+    }
 }
 
 

--- a/Detours/Detours.vcxproj
+++ b/Detours/Detours.vcxproj
@@ -40,13 +40,25 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{79DB420C-0C71-4948-A93C-821761A8105B}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <SubSystem>Windows</SubSystem>
     <!-- Enable the following to compile Detours in debug mode -->
     <DebugDetours>false</DebugDetours>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\Common.props" />

--- a/Detours/detours.cpp
+++ b/Detours/detours.cpp
@@ -204,7 +204,7 @@ inline void detour_find_jmp_bounds(PBYTE pbCode,
     // We have to place trampolines within +/- 2GB of code.
     ULONG_PTR lo = detour_2gb_below((ULONG_PTR)pbCode);
     ULONG_PTR hi = detour_2gb_above((ULONG_PTR)pbCode);
-    DETOUR_TRACE(("[%p..%p..%p]\n", lo, pbCode, hi));
+    DETOUR_TRACE(("[%p..%p..%p]\n", (void *)lo, (void *)pbCode, (void *)hi));
 
     // And, within +/- 2GB of relative jmp targets.
     if (pbCode[0] == 0xe9) {   // jmp +imm32
@@ -216,7 +216,7 @@ inline void detour_find_jmp_bounds(PBYTE pbCode,
         else {
             lo = detour_2gb_below((ULONG_PTR)pbNew);
         }
-        DETOUR_TRACE(("[%p..%p..%p] +imm32\n", lo, pbCode, hi));
+        DETOUR_TRACE(("[%p..%p..%p] +imm32\n", (void *)lo, (void*)pbCode, (void*)hi));
     }
 
     *ppLower = (PDETOUR_TRAMPOLINE)lo;
@@ -417,7 +417,7 @@ inline void detour_find_jmp_bounds(PBYTE pbCode,
     // We have to place trampolines within +/- 2GB of code.
     ULONG_PTR lo = detour_2gb_below((ULONG_PTR)pbCode);
     ULONG_PTR hi = detour_2gb_above((ULONG_PTR)pbCode);
-    DETOUR_TRACE(("[%p..%p..%p]\n", lo, pbCode, hi));
+    DETOUR_TRACE(("[%p..%p..%p]\n", (void*)lo, (void*)pbCode, (void*)hi));
 
     // And, within +/- 2GB of relative jmp vectors.
     if (pbCode[0] == 0xff && pbCode[1] == 0x25) {   // jmp [+imm32]
@@ -429,7 +429,7 @@ inline void detour_find_jmp_bounds(PBYTE pbCode,
         else {
             lo = detour_2gb_below((ULONG_PTR)pbNew);
         }
-        DETOUR_TRACE(("[%p..%p..%p] [+imm32]\n", lo, pbCode, hi));
+        DETOUR_TRACE(("[%p..%p..%p] [+imm32]\n", (void*)lo, (void*)pbCode, (void*)hi));
     }
     // And, within +/- 2GB of relative jmp targets.
     else if (pbCode[0] == 0xe9) {   // jmp +imm32
@@ -441,7 +441,7 @@ inline void detour_find_jmp_bounds(PBYTE pbCode,
         else {
             lo = detour_2gb_below((ULONG_PTR)pbNew);
         }
-        DETOUR_TRACE(("[%p..%p..%p] +imm32\n", lo, pbCode, hi));
+        DETOUR_TRACE(("[%p..%p..%p] +imm32\n", (void*)lo, (void*)pbCode, (void*)hi));
     }
 
     *ppLower = (PDETOUR_TRAMPOLINE)lo;

--- a/Detours/uimports.cpp
+++ b/Detours/uimports.cpp
@@ -139,7 +139,7 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
     }
     DETOUR_TRACE(("pbBase = %p\n", pbBase));
 
-    PBYTE pbNewIid = FindAndAllocateNearBase(hProcess, pbBase, cbNew);
+    PBYTE pbNewIid = FindAndAllocateNearBase(hProcess, pbModule, pbBase, cbNew);
     if (pbNewIid == NULL) {
         DETOUR_TRACE(("FindAndAllocateNearBase failed.\n"));
         goto finish;

--- a/PsfLauncher/PsfLauncher.vcxproj
+++ b/PsfLauncher/PsfLauncher.vcxproj
@@ -54,23 +54,23 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{29EE27EF-A3A3-4B8F-8DA2-532A5C04BD9E}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\Fixups.props" />

--- a/PsfLauncher/PsfLauncher.vcxproj
+++ b/PsfLauncher/PsfLauncher.vcxproj
@@ -79,6 +79,18 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <Import Project="$(MSBuildThisFileDirectory)\..\Common.Build.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <!-- For some reason Visual Studio ignores ItemDefinitionGroup settings from props files if there's no
          ItemDefinitionGroup in the vcxproj, even if it's empty... -->

--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -343,12 +343,12 @@ private:
 			if (inside)
 			{
 				//LogString(L"DEBUG: Starting the script (inside) without waiting to finish", script.commandString.data());
-				std::thread(StartProcess, script.PsPath.c_str(), script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeListInside.get());
+				auto res = std::thread(StartProcess, script.PsPath.c_str(), script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeListInside.get());
 			}
 			else
 			{
 				//LogString(L"DEBUG: Starting the script (outside) without waiting to finish", script.commandString.data());
-				std::thread(StartProcess, script.PsPath.c_str(), script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeListOutside.get());
+				auto res = std::thread(StartProcess, script.PsPath.c_str(), script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeListOutside.get());
 			}
 		}
 	}

--- a/PsfLauncher/Readme.md
+++ b/PsfLauncher/Readme.md
@@ -21,6 +21,40 @@ If you need debugging of the fixup modules, you may include the Debug builds of 
 This debug output is more useful in debugging the fixup itself rather than debugging the app.
 If you are not interested in fixing the PSF, you would be better served to include the PsfTraceFixup for debugging instead.
 
+## About PsfLauncher and Processes needing elevation
+There is an inherent conflict that exists when an un-elevated launcher process 
+wants to start a new process with elevation, plus wants to make sure it starts inside the container,
+plus wants to start it suspended so that dll injection can occur. 
+
+Previously, this caused the target application to launch with the elevation but without the injected dlls.
+
+The internal manifest file has now been removed from PsfLauncher. 
+This change, by itself, will have no impact on any packages.
+However, this change allows someone adding the PSF into a package 
+to detect situationw where the internal manifest file settings of 
+the target executable to be started by the launcher, and to then add an additional external
+manifest file to the PsfLauncher copy inside the package.  
+
+This external manifest file would use the same name 
+as that used for the PsfLauncher copy in the package 
+with a `.manifest` file extension added after the `.exe`.
+The external manifest file only needs the `requestedExecutionLevel` settings for `level` and `uiAccess` (all additional manifest settings from the target should be ignogred).
+
+Here is an example external manifest file:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns:amsv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+	<amsv3:trustInfo>
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+			</requestedPrivileges>
+		</security>
+	</amsv3:trustInfo>
+</assembly>
+```
+
+
 ## Configuration
 PSF Launcher uses a config.json file to configure the behavior.
 This file is normally placed in the root folder of the package, however it may be put anywhere in the package.

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -60,7 +60,7 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
 
-    return exitCode; // ERROR_SUCCESS;
+    return ERROR_SUCCESS;  // Some apps return codes even when happy.
 }
 
 void StartWithShellExecute(LPCWSTR verb, std::filesystem::path packageRoot, std::filesystem::path exeName, std::wstring exeArgString, LPCWSTR dirStr, int cmdShow, DWORD timeout)

--- a/PsfRunDll/PsfRunDll.vcxproj
+++ b/PsfRunDll/PsfRunDll.vcxproj
@@ -24,23 +24,23 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{2896A610-9654-43BE-8493-B74D1BC44FD9}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\Fixups.props" />

--- a/PsfRuntime/Config.cpp
+++ b/PsfRuntime/Config.cpp
@@ -297,35 +297,37 @@ void load_json()
         }
     }
 
-
-    char buffer[2048];
-    rapidjson::FileReadStream stream(file, buffer, std::size(buffer));
-    rapidjson::AutoUTFInputStream<char32_t, rapidjson::FileReadStream> autoStream(stream);
-
-    rapidjson::GenericReader<rapidjson::AutoUTF<char32_t>, rapidjson::UTF8<>> reader;
-    auto result = reader.Parse(autoStream, g_JsonHandler);
-    fclose(file);
-
-    if (result.IsError())
+    if (file)
     {
-        std::stringstream msgStream;
-        msgStream << "Error occurred when parsing config.json\n";
-        if (g_JsonHandler.error_message.empty())
-        {
-            msgStream << "Error: " << rapidjson::GetParseError_En(result.Code()) << "\n";
-        }
-        else
-        {
-            msgStream << "Error: " << g_JsonHandler.error_message << "\n";
-        }
-        msgStream << "File Offest: " << result.Offset();
-        throw std::runtime_error(msgStream.str());
-    }
-    else if (!g_JsonHandler.root)
-    {
-        throw std::runtime_error("config.json has no contents");
-    }
+        char buffer[2048];
+        rapidjson::FileReadStream stream(file, buffer, std::size(buffer));
+        rapidjson::AutoUTFInputStream<char32_t, rapidjson::FileReadStream> autoStream(stream);
 
+        rapidjson::GenericReader<rapidjson::AutoUTF<char32_t>, rapidjson::UTF8<>> reader;
+        auto result = reader.Parse(autoStream, g_JsonHandler);
+        fclose(file);
+
+
+        if (result.IsError())
+        {
+            std::stringstream msgStream;
+            msgStream << "Error occurred when parsing config.json\n";
+            if (g_JsonHandler.error_message.empty())
+            {
+                msgStream << "Error: " << rapidjson::GetParseError_En(result.Code()) << "\n";
+            }
+            else
+            {
+                msgStream << "Error: " << g_JsonHandler.error_message << "\n";
+            }
+            msgStream << "File Offest: " << result.Offset();
+            throw std::runtime_error(msgStream.str());
+        }
+        else if (!g_JsonHandler.root)
+        {
+            throw std::runtime_error("config.json has no contents");
+        }
+    }
     assert(g_JsonHandler.state_stack.empty());
 
     // Cache a pointer to the current executable's config, as we are most likely to reference that later

--- a/PsfRuntime/PsfRuntime.vcxproj
+++ b/PsfRuntime/PsfRuntime.vcxproj
@@ -40,23 +40,23 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{87CCE0AC-A7FB-4A31-89D3-C0ACDB315EE0}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\Fixups.props" />
@@ -68,6 +68,18 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>PSFRUNTIME_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+      </DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </DisableSpecificWarnings>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/Wv:18 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/Wv:18 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/Wv:18 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/Wv:18 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>PsfRuntime.def</ModuleDefinitionFile>

--- a/PsfRuntime/main.cpp
+++ b/PsfRuntime/main.cpp
@@ -85,7 +85,7 @@ void load_fixups()
                             if (!fixup.module_handle)
                             {
 #if _DEBUG
-                                Log("\tfixup not found at cwd,checkroot of package." );
+                                Log("\tfixup not found as specified,checkroot of package." );
 #endif
                                 std::filesystem::path pathfromroot = PackageRootPath() / path.filename().c_str();
                                 fixup.module_handle = ::LoadLibraryW(pathfromroot.c_str());

--- a/PsfRuntime/main.cpp
+++ b/PsfRuntime/main.cpp
@@ -50,6 +50,7 @@ struct loaded_fixup
 std::vector<loaded_fixup> loaded_fixups;
 
 bool usingPsf = false;
+wchar_t g_PsfRunTimeModulePath[MAX_PATH];
 
 void load_fixups()
 {
@@ -281,7 +282,7 @@ void detach()
     }
 }
 
-BOOL APIENTRY DllMain(HMODULE, DWORD reason, LPVOID) noexcept try
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID) noexcept try
 {
     Log("PsfRuntime: In DllMain Pid=%d Tid=%d", GetCurrentProcessId(), GetCurrentThreadId());
     // Per detours documentation, immediately return true if running in a helper process
@@ -296,6 +297,11 @@ BOOL APIENTRY DllMain(HMODULE, DWORD reason, LPVOID) noexcept try
     case DLL_PROCESS_ATTACH:
         try
         {
+            // Record the location for ourselves in case we need to inject it into another new process (CreateProcessHook.cpp).
+            if (::GetModuleFileName(hModule, g_PsfRunTimeModulePath, MAX_PATH) == 0)
+            {
+                g_PsfRunTimeModulePath[0] = 0x0;
+            }
             attach();
         }
         catch (...)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# A NOTE ABOUT THIS FORK
+While Microsoft created the initial open-source project for the Package Support Framework, they have neglected it for some time and seem disinterested in maintaining it, so this fork represents the lastest active branch.
+    ![PsfLogo](https://user-images.githubusercontent.com/19534997/151001486-af6b65de-9046-4b23-9112-4916a844e81c.png)
+
 # Package Support Framework
 This project provides tools, libraries, documentation and samples for creating runtime fixes (also called *fixups*) for compatibility issues that enable Windows desktop applications to be distributed and executed as MSIX packaged apps.
 

--- a/fixups/DynamicLibraryFixup/DynamicLibraryFixup.cpp
+++ b/fixups/DynamicLibraryFixup/DynamicLibraryFixup.cpp
@@ -8,6 +8,10 @@
 #include "FunctionImplementations.h"
 #include "dll_location_spec.h"
 
+#if _DEBUG
+#define MOREDEBUG 1
+#endif
+
 extern bool                  g_dynf_forcepackagedlluse;
 extern std::vector<dll_location_spec> g_dynf_dllSpecs;
 
@@ -25,7 +29,7 @@ HMODULE __stdcall LoadLibraryFixup(_In_ const CharT* libFileName)
     if (guard)
     {
 #if _DEBUG
-        //Log(L"LoadLibraryFixup unguarded.");
+        Log(L"LoadLibraryFixup unguarded.");
 #endif
         // Check against known dlls in package.
         std::wstring libFileNameW = GetFilenameOnly(InterpretStringW(libFileName));
@@ -42,8 +46,8 @@ HMODULE __stdcall LoadLibraryFixup(_In_ const CharT* libFileName)
 #endif
                 try
                 {
-#if _DEBUG
-                    //LogString(L"LoadLibraryFixup testing against", spec.filename.data());
+#if MOREDEBUG
+                    LogString(L"LoadLibraryFixup testing against", spec.filename.data());
 #endif
                     if (spec.filename.compare(libFileNameW + L".dll") == 0 ||
                         spec.filename.compare(libFileNameW) == 0)
@@ -100,6 +104,10 @@ HMODULE __stdcall LoadLibraryFixup(_In_ const CharT* libFileName)
                     Log(L"LoadLibraryFixup ERROR");
                 }
             }
+
+#if _DEBUG
+            Log(L"LoadLibraryFixup found no match.");
+#endif
         }
     }
     result = LoadLibraryImpl(libFileName);

--- a/fixups/DynamicLibraryFixup/DynamicLibraryFixup.cpp
+++ b/fixups/DynamicLibraryFixup/DynamicLibraryFixup.cpp
@@ -48,11 +48,51 @@ HMODULE __stdcall LoadLibraryFixup(_In_ const CharT* libFileName)
                     if (spec.filename.compare(libFileNameW + L".dll") == 0 ||
                         spec.filename.compare(libFileNameW) == 0)
                     {
+                        bool useThis = true;
+                        BOOL procTest = false;
+                        switch (spec.architecture)
+                        {
+                        case x86:
+                            if (IsWow64Process(GetCurrentProcess(), &procTest))
+                            {
+                                if (procTest == FALSE)
+                                {
+                                    // 32 bit process on an x64 OS
+                                    useThis = true;
+                                }
+                            }
+                            else
+                            {
+                                // 32bit OS
+                                useThis = true;
+                            }
+                            break;
+                        case x64:
+                            if (IsWow64Process(GetCurrentProcess(), &procTest))
+                            {
+                                if (procTest == TRUE)
+                                {
+                                    // 64 bit process on an x64 OS
+                                    useThis = true;
+                                }
+                            }
+                            break;
+                        case AnyCPU:
+                            useThis = true;
+                            break;
+                        case NotSpecified:
+                        default:
+                            break;
+                        }
+
+                        if (useThis)
+                        {
 #if _DEBUG
-                        LogString(L"LoadLibraryFixup using", spec.full_filepath.c_str());
+                            LogString(L"LoadLibraryFixup using", spec.full_filepath.c_str());
 #endif
-                        result = LoadLibraryImpl(spec.full_filepath.c_str());
-                        return result;
+                            result = LoadLibraryImpl(spec.full_filepath.c_str());
+                            return result;
+                        }
                     }
                 }
                 catch (...)

--- a/fixups/DynamicLibraryFixup/DynamicLibraryFixup.vcxproj
+++ b/fixups/DynamicLibraryFixup/DynamicLibraryFixup.vcxproj
@@ -43,7 +43,7 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{40F9058D-8059-4ED4-859E-7A548A73CA4F}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -51,16 +51,16 @@
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)\..\..\Fixups.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/fixups/DynamicLibraryFixup/InitializeFixup.cpp
+++ b/fixups/DynamicLibraryFixup/InitializeFixup.cpp
@@ -19,6 +19,10 @@
 #include "FunctionImplementations.h"
 #include "dll_location_spec.h"
 
+#if _DEBUG
+#define MOREDEBUG 1
+#endif
+
 using namespace std::literals;
 
 std::filesystem::path g_dynf_packageRootPath;
@@ -80,15 +84,16 @@ void InitializeConfiguration()
                     {
                         auto& specObject = spec.as_object();
 
-                        auto filename = specObject.get("name").as_string().wstring();
+                        std::wstring_view filename = specObject.get("name").as_string().wstring();
 
                         auto relpath = specObject.get("filepath").as_string().wstring();
                         std::filesystem::path fullpath = g_dynf_packageRootPath / relpath;
 
                         dllBitness bitness = NotSpecified;
+                        std::wstring wArch = L"";
                         if (auto arch = specObject.try_get("architecture"))
                         {
-                            auto wArch = arch->as_string().wstring();
+                            wArch = arch->as_string().wstring();
                             if (wArch.compare(L"x86"))
                             {
                                 bitness = x86;
@@ -106,6 +111,9 @@ void InitializeConfiguration()
                         g_dynf_dllSpecs.back().full_filepath = fullpath;
                         g_dynf_dllSpecs.back().filename = filename;
                         g_dynf_dllSpecs.back().architecture = bitness;
+#if MOREDEBUG
+                        Log(L"DynamicLibraryFixup: %s : (%s) : %s", filename.data(), wArch.c_str(), fullpath.c_str());
+#endif
                         count++;
                     };
 #if _DEBUG

--- a/fixups/DynamicLibraryFixup/InitializeFixup.cpp
+++ b/fixups/DynamicLibraryFixup/InitializeFixup.cpp
@@ -85,9 +85,27 @@ void InitializeConfiguration()
                         auto relpath = specObject.get("filepath").as_string().wstring();
                         std::filesystem::path fullpath = g_dynf_packageRootPath / relpath;
 
+                        dllBitness bitness = NotSpecified;
+                        if (auto arch = specObject.try_get("architecture"))
+                        {
+                            auto wArch = arch->as_string().wstring();
+                            if (wArch.compare(L"x86"))
+                            {
+                                bitness = x86;
+                            }
+                            else if (wArch.compare(L"x86"))
+                            {
+                                bitness = x64;
+                            }
+                            else if (wArch.compare(L"anyCPU"))
+                            {
+                                bitness = AnyCPU;
+                            }
+                        }
                         g_dynf_dllSpecs.emplace_back();
                         g_dynf_dllSpecs.back().full_filepath = fullpath;
                         g_dynf_dllSpecs.back().filename = filename;
+                        g_dynf_dllSpecs.back().architecture = bitness;
                         count++;
                     };
 #if _DEBUG

--- a/fixups/DynamicLibraryFixup/dll_location_spec.h
+++ b/fixups/DynamicLibraryFixup/dll_location_spec.h
@@ -5,8 +5,16 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+typedef enum dllBitness
+{
+    x86,
+    x64,
+    AnyCPU,
+    NotSpecified
+} DllBitness;
 struct dll_location_spec
 {
     std::filesystem::path full_filepath;
     std::wstring_view filename;
+    dllBitness architecture;
 };

--- a/fixups/DynamicLibraryFixup/readme.md
+++ b/fixups/DynamicLibraryFixup/readme.md
@@ -1,11 +1,17 @@
-# Env Var Fixup
-When injected into a process, the EnvVarFixup supports the ability to:
-> * Define environment variables in the Config.Json file.
-> * Specify that a named environment variable should be extracted from the application
-> * hive registry.
+# DynamicLibrary Fixup
+When injected into a process, the DynamicLibraryFixup supports the ability to:
+> * Define mappings between dll name and location within the package in the Config.Json file.
+> * Ensure that the named dll will be found within the package anytime the application tries to load the dll.
 
-MSIX packages do not normally implement any environment variables outside of what is normally set on the system outside of the container.
-In essence, this fixup allows you to specify what would natively be a system or user environment variable as an application-specific environment variable.
+There are a bunch of reasons that the traditional ways of apps locating their dlls fail under MSIX.
+Although there are specific fixes for many of these issues, this fixup creates a sure-fire way to get it loaded.
+
+### Detecting the need for this fixup
+The primary causes for needing this fixup are situations where the original product depended up changes to the Path Environment Variable, or App Paths registration of additional folders that contain dlls.
+It can also happen due to a change in Working Directory.
+
+At runtime within the container, the symptom showing the need will be a dll not found issue for a dll that is in the package.
+
 
 ## About Debugging this fixup
 The Release build of this fixup produces no output to the debug console port for performance reasons.
@@ -18,42 +24,50 @@ This `config` element contains a an array called "EnvVars".  Each Envar contains
 
 | PropertyName | Description |
 | ------------ | ----------- |
-| `name` | Regex pattern for the name(s) of the environment variable being defined.|
-| `value`| If the value is to be defined in the json, the value is entered here. Otherwise this may be specified as an empty string.|
-| `useregistry`| A boolean, when set to true it instructs that the environment variable should be extracted from the package registry for Environment variables, first checking HKCU and then HKLM. When specified, the intercept will first look in the HKCU registry, then HKLM, and finally the `value` field in the JSON entry. |
+| `forcePackageDllUse` | Boolean.  Set to true.|
+| `relativeDllPaths` | An array. See below. |
 
+Each element of the array has the following structure:
+
+| PropertyName | Description |
+| ------------ | ----------- |
+| `name`| This is the name as requested by the application. This will be the name of the file, without any path information and without the filename extension.|
+| `filepath`| The filepath relative to the root folder of the package. |
+| `achitecure`| An optional value to speficy the 'bitness' of the dll.  Supported values include `x86`, `x64`, and `anyCPU`. When not specified, no checking for archtecture of the process and dll will be made.|
+
+The `architecure` is optional and normally need not be specified for simplicity. It is included because sometimes an app contains both 32 and 64 bit exes for different purposes that need to load the correct version of the same named dll, typically stored in a different folder. When the package has this situation, it is then necessary to specify the architecture.  The fixup for LoadDll will match up the appropriate version of the dll based on the process it is running under.
 
 # JSON Examples
 To make things simpler to understand, here is a potential example configuration object that is not using the optional parameters:
 
 ```json
 "config": {
-    "EnvVars": [
+    "forcePackageDllUse": "true",
+    "relativeDllPaths": [
         {
-            "name" : "Var1Name",
-            "value" : "SpecifiedValue1",
-            "useregistry": "false"
+            "name" : "DllName_without_DotDll",
+            "filepath" : "RelativePathToFile_including_DllName_without_DotDll.dll"
         },
         {
-            "name" : "Var2Name",
-            "value" : "BackupValue2",
-            "useregistry": "true"
-        }
-        ,
+            "name" : "DllName2",
+            "filepath" : "VFS\ProgramFilesX84\Vendor\App\Subfolder\DllName2.dll"
+        },
         {
-            "name" : "MyName.\*",
-            "value" : "",
-            "useregistry": "true"
+            "name" : "DllNameX",
+            "filepath" : "VFS\ProgramFilesX84\Vendor\App\x64\DllNameX.dll",
+            "architecture" : "x64"
+        },
+        {
+            "name" : "DllNameX",
+            "filepath" : "VFS\ProgramFilesX84\Vendor\App\32bit\DllNameX.dll",
+            "architecture" : "x86"
+        },
+        {
+            "name" : "DllNameY",
+            "filepath" : "VFS\ProgramFilesX84\Vendor\App\Subdir\DllNameY.dll",
+            "architecture" : "anyCPU"
         }
     ]
 }
 ```
-
-Note that when using registry entries, the search looks at the registry as seen by the application inside the container.
-Thus a HKCU search should see entries in the Application hive overlayed over the local system.
-The HKLM search does the same, but on some systems (all at the time this was written) the HKLM\System entries in the Application hive might not be seen by the application.
-
-When useregistry is not specified, any attempt by the application to set an environment variable will return an ERROR_ACCESS_DENIED event without attempting to set the value.
-
-When useregistry is specified, regardless of where the value was located, it will be written to the HKCU\EnvironmentVariables key so that the write will succeed on systems that support it.
 

--- a/fixups/EnvVarFixup/EnvVarFixup.vcxproj
+++ b/fixups/EnvVarFixup/EnvVarFixup.vcxproj
@@ -23,19 +23,19 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{aa616ed2-6783-40ae-9197-b257e8b17690}</ProjectGuid>
     <RootNamespace>EnvVarFixup</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>
     </WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
@@ -43,13 +43,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/fixups/EnvVarFixup/readme.md
+++ b/fixups/EnvVarFixup/readme.md
@@ -26,7 +26,9 @@ Each element of the array has the following structure:
 | ------------ | ----------- |
 | `name`| This is the name as requested by the application. This will be the name of the file, without any path information and without the filename extension.|
 | `filepath`| The filepath relative to the root folder of the package. |
+| `achitecure`| An optional value to speficy the 'bitness' of the dll.  Supported values include `x86`, `x64`, and `anyCPU`. When not specified, no checking for archtecture of the process and dll will be made.|
 
+The `architecure` is optional and normally need not be specified for simplicity. It is included because sometimes an app contains both 32 and 64 bit exes for different purposes that need to load the correct version of the same named dll, typically stored in a different folder. When the package has this situation, it is then necessary to specify the architecture.  The fixup for LoadDll will match up the appropriate version of the dll based on the process it is running under.
 
 # JSON Examples
 To make things simpler to understand, here is a potential example configuration object that is not using the optional parameters:
@@ -46,7 +48,14 @@ To make things simpler to understand, here is a potential example configuration 
         ,
         {
             "name" : "DllNameX",
-            "filepath" : "filepathX"
+            "filepath" : "VFS\ProgramFilesX84\Vendor\App\x64\DllNameX.dll",
+            "architecture" : "x64"
+        }
+        ,
+        {
+            "name" : "DllNameX",
+            "filepath" : "VFS\ProgramFilesX84\Vendor\App\32bit\DllNameX.dll",
+            "architecture" : "x86"
         }
     ]
 }

--- a/fixups/FileRedirectionFixup/FileRedirectionFixup.vcxproj
+++ b/fixups/FileRedirectionFixup/FileRedirectionFixup.vcxproj
@@ -64,26 +64,26 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{A3653AD0-2406-48A4-95CD-7D4264257F9F}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/fixups/FileRedirectionFixup/FindFirstFileFixupV2.cpp
+++ b/fixups/FileRedirectionFixup/FindFirstFileFixupV2.cpp
@@ -176,26 +176,26 @@ HANDLE __stdcall FindFirstFileExFixupV2(
 #if _DEBUG
     LogString(FindFirstFileExInstanceV2, L"\tFindFirstFileExFixupV2: for fileName", wFileName.c_str());
     if (psf::is_ansi<CharT>)
-        Log(L"[%d]DEBUG IsAnsi call", FindFirstFileExInstanceV2);
+        Log(L"[%d] DEBUG IsAnsi call", FindFirstFileExInstanceV2);
     else
-        Log(L"[%d]DEBUG IsWide call", FindFirstFileExInstanceV2);
+        Log(L"[%d] DEBUG IsWide call", FindFirstFileExInstanceV2);
 
     switch (searchOp)
     {
     case FindExSearchNameMatch:
-        Log(L"[%d]SearchOp FindExSearchNameMatch",FindFirstFileExInstanceV2);
+        Log(L"[%d] SearchOp FindExSearchNameMatch",FindFirstFileExInstanceV2);
             break;
     case FindExSearchLimitToDirectories:
-        Log(L"[%d]SearchOp FindExSearchLimitToDirectories", FindFirstFileExInstanceV2);
+        Log(L"[%d] SearchOp FindExSearchLimitToDirectories", FindFirstFileExInstanceV2);
         break;
     case FindExSearchLimitToDevices:
-        Log(L"[%d]SearchOp FindExSearchLimitToDevices", FindFirstFileExInstanceV2);
+        Log(L"[%d] SearchOp FindExSearchLimitToDevices", FindFirstFileExInstanceV2);
         break;
     case FindExSearchMaxSearchOp:
-        Log(L"[%d]SearchOp FindExSearchMaxSearchOp", FindFirstFileExInstanceV2);
+        Log(L"[%d] SearchOp FindExSearchMaxSearchOp", FindFirstFileExInstanceV2);
         break;
     default:
-        Log(L"[%d]SearchOp Unknown=0x%x", FindFirstFileExInstanceV2,searchOp);
+        Log(L"[%d] SearchOp Unknown=0x%x", FindFirstFileExInstanceV2,searchOp);
         break;
     }
 #endif
@@ -205,7 +205,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
         {
             // This case is an invalid find request that accidentally works in normal find calls, but our redirection gets messed up.
 #if _DEBUG
-            Log(L"[%d]DEBUG TEST: Tweek bad call", FindFirstFileExInstanceV2);
+            Log(L"[%d] DEBUG TEST: Tweek bad call", FindFirstFileExInstanceV2);
 #endif
             wFileName[wFileName.length()-2] = wFileName[wFileName.length()-1];
             wFileName.resize(wFileName.length() - 1);
@@ -234,11 +234,11 @@ HANDLE __stdcall FindFirstFileExFixupV2(
     result->package_deredirect_path = pathDeRedirected;
 
 #if _DEBUG
-    Log(L"[%d]FindFirstFileExFixupV2 redirect_path        for [0] (from redir)   is %ls", FindFirstFileExInstanceV2, result->redirect_path.c_str());
-    Log(L"[%d]FindFirstFileExFixupV2 package_vfs_path     for [1] (from VFS)     is %ls", FindFirstFileExInstanceV2, result->package_vfs_path.c_str());
-    Log(L"[%d]FindFirstFileExFixupV2 requested_path       for [2] (from req)     is %ls", FindFirstFileExInstanceV2, result->requested_path.c_str());
-    Log(L"[%d]FindFirstFileExFixupV2 package_devfs_path   for [3] (from DeVFS)   is %ls", FindFirstFileExInstanceV2, result->package_devfs_path.c_str());
-    Log(L"[%d]FindFirstFileExFixupV2 package_deredir_path for [4] (from DeRedir) is %ls", FindFirstFileExInstanceV2, result->package_deredirect_path.c_str());
+    Log(L"[%d] FindFirstFileExFixupV2 redirect_path        for [0] (from redir)   is %ls", FindFirstFileExInstanceV2, result->redirect_path.c_str());
+    Log(L"[%d] FindFirstFileExFixupV2 package_vfs_path     for [1] (from VFS)     is %ls", FindFirstFileExInstanceV2, result->package_vfs_path.c_str());
+    Log(L"[%d] FindFirstFileExFixupV2 requested_path       for [2] (from req)     is %ls", FindFirstFileExInstanceV2, result->requested_path.c_str());
+    Log(L"[%d] FindFirstFileExFixupV2 package_devfs_path   for [3] (from DeVFS)   is %ls", FindFirstFileExInstanceV2, result->package_devfs_path.c_str());
+    Log(L"[%d] FindFirstFileExFixupV2 package_deredir_path for [4] (from DeRedir) is %ls", FindFirstFileExInstanceV2, result->package_deredirect_path.c_str());
 #endif
 
     [[maybe_unused]] auto ansiData = reinterpret_cast<WIN32_FIND_DATAA*>(findFileData);
@@ -273,7 +273,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                 copy_find_data(*wideData, result->cached_data);
             }
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[0] (from redirected): had results %ls", FindFirstFileExInstanceV2,findData->cFileName);
+            Log(L"[%d] FindFirstFileExFixupV2[0] (from redirected): had results %ls", FindFirstFileExInstanceV2,findData->cFileName);
 #endif
             AnyValidPath = true;
             AnyValidResult = true;
@@ -286,7 +286,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
             // Path doesn't exist or match any files. We can safely get away without the redirected file exists check
             result->redirect_path.clear();
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[0] (from redirected): no results", FindFirstFileExInstanceV2);
+            Log(L"[%d] FindFirstFileExFixupV2[0] (from redirected): no results", FindFirstFileExInstanceV2);
 #endif
         }
 
@@ -296,7 +296,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
     else
     {
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2[0] (from redirected): no results possible", FindFirstFileExInstanceV2);
+        Log(L"[%d] FindFirstFileExFixupV2[0] (from redirected): no results possible", FindFirstFileExInstanceV2);
 #endif
     }
 
@@ -313,7 +313,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
         if (result->find_handles[1])
         {
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[1] (from vfs_path):   had results", FindFirstFileExInstanceV2);
+            Log(L"[%d] FindFirstFileExFixupV2[1] (from vfs_path):   had results", FindFirstFileExInstanceV2);
 #endif
             AnyValidPath = true;
             AnyValidResult = true;
@@ -325,7 +325,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                 AnyValidPath = true;
             result->package_vfs_path.clear();
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[1] (from vfs_path):   no results", FindFirstFileExInstanceV2);
+            Log(L"[%d] FindFirstFileExFixupV2[1] (from vfs_path):   no results", FindFirstFileExInstanceV2);
 #endif
         }
         if (!result->find_handles[0])
@@ -337,7 +337,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                     if (copy_find_data(*findData, *ansiData))
                     {
 #if _DEBUG
-                        Log(L"[%d]FindFirstFile error set by caller", FindFirstFileExInstanceV2);
+                        Log(L"[%d] FindFirstFile error set by caller", FindFirstFileExInstanceV2);
 #endif
                         // NOTE: Last error set by caller
                         return INVALID_HANDLE_VALUE;
@@ -358,7 +358,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
     else
     {
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2[1] (from vfs_path):   no results possible", FindFirstFileExInstanceV2);
+        Log(L"[%d] FindFirstFileExFixupV2[1] (from vfs_path):   no results possible", FindFirstFileExInstanceV2);
 #endif
     }
 
@@ -368,7 +368,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
     if (result->find_handles[2])
     {
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2[2] (from origial):    had results", FindFirstFileExInstanceV2);
+        Log(L"[%d] FindFirstFileExFixupV2[2] (from origial):    had results", FindFirstFileExInstanceV2);
 #endif
         AnyValidPath = true; 
         AnyValidResult = true;
@@ -380,7 +380,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
             AnyValidPath = true;
         result->requested_path.clear();
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2[2] (from original):   no results", FindFirstFileExInstanceV2);
+        Log(L"[%d] FindFirstFileExFixupV2[2] (from original):   no results", FindFirstFileExInstanceV2);
 #endif
     }
     if (!result->find_handles[0] &&
@@ -393,7 +393,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                 if (copy_find_data(*findData, *ansiData))
                 {
 #if _DEBUG
-                    Log(L"[%d]FindFirstFileExFixupV2 error set by caller", FindFirstFileExInstanceV2);
+                    Log(L"[%d] FindFirstFileExFixupV2 error set by caller", FindFirstFileExInstanceV2);
 #endif
                     // NOTE: Last error set by caller
                     return INVALID_HANDLE_VALUE;
@@ -418,7 +418,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
         if (result->find_handles[3])
         {
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[3] (from devirt):     had results", FindFirstFileExInstanceV2);
+            Log(L"[%d] FindFirstFileExFixupV2[3] (from devirt):     had results", FindFirstFileExInstanceV2);
 #endif
             AnyValidPath = true; 
             AnyValidResult = true;
@@ -430,7 +430,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                 AnyValidPath = true;
             result->requested_path.clear();
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[3] (from devirt):     no results", FindFirstFileExInstanceV2);
+            Log(L"[%d] FindFirstFileExFixupV2[3] (from devirt):     no results", FindFirstFileExInstanceV2);
 #endif
         }
         if (!result->find_handles[0] &&
@@ -444,7 +444,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                     if (copy_find_data(*findData, *ansiData))
                     {
 #if _DEBUG
-                        Log(L"[%d]FindFirstFileExFixupV2 error set by caller", FindFirstFileExInstanceV2);
+                        Log(L"[%d] FindFirstFileExFixupV2 error set by caller", FindFirstFileExInstanceV2);
 #endif
                         // NOTE: Last error set by caller
                         return INVALID_HANDLE_VALUE;
@@ -464,7 +464,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
     else
     {
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2[3] (from devirt):     no results possible", FindFirstFileExInstanceV2);
+        Log(L"[%d] FindFirstFileExFixupV2[3] (from devirt):     no results possible", FindFirstFileExInstanceV2);
 #endif
     }
 
@@ -476,7 +476,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
         if (result->find_handles[4])
         {
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[4] (from deredir):    had results", FindFirstFileExInstanceV2);
+            Log(L"[%d] FindFirstFileExFixupV2[4] (from deredir):    had results", FindFirstFileExInstanceV2);
 #endif
             AnyValidPath = true;
             AnyValidResult = true;
@@ -488,7 +488,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                 AnyValidPath = true;
             result->requested_path.clear();
 #if _DEBUG
-            Log(L"[%d]FindFirstFileExFixupV2[4] (from deredir):   no results", FindFirstFileExInstanceV2);
+            Log(L"[%d] FindFirstFileExFixupV2[4] (from deredir):   no results", FindFirstFileExInstanceV2);
 #endif
         }
         if (!result->find_handles[0] &&
@@ -503,7 +503,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
                     if (copy_find_data(*findData, *ansiData))
                     {
 #if _DEBUG
-                        Log(L"[%d]FindFirstFile2 error set by caller", FindFirstFileExInstanceV2);
+                        Log(L"[%d] FindFirstFileV2 error set by caller", FindFirstFileExInstanceV2);
 #endif
                         // NOTE: Last error set by caller
                         return INVALID_HANDLE_VALUE;
@@ -521,7 +521,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
     else
     {
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2[4] (from deredir):    no results possible", FindFirstFileExInstanceV2);
+        Log(L"[%d] FindFirstFileExFixupV2[4] (from deredir):    no results possible", FindFirstFileExInstanceV2);
 #endif
     }
 
@@ -536,7 +536,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
             //result->cached_data = ansiData;  
         }
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2 returns %ls", FindFirstFileExInstanceV2, result->cached_data.cFileName);
+        Log(L"[%d] FindFirstFileExFixupV2 returns %ls", FindFirstFileExInstanceV2, result->cached_data.cFileName);
 #endif
         result->already_returned_list.push_back(result->cached_data.cFileName);
         ::SetLastError(ERROR_SUCCESS);
@@ -550,7 +550,7 @@ HANDLE __stdcall FindFirstFileExFixupV2(
             initialFindError = ERROR_FILE_NOT_FOUND;
         }
 #if _DEBUG
-        Log(L"[%d]FindFirstFileExFixupV2 returns 0x%x", FindFirstFileExInstanceV2, initialFindError);
+        Log(L"[%d] FindFirstFileExFixupV2 returns 0x%x", FindFirstFileExInstanceV2, initialFindError);
 #endif
         ::SetLastError(initialFindError);
         return INVALID_HANDLE_VALUE;
@@ -610,7 +610,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
     if (findFile == INVALID_HANDLE_VALUE)
     {
 #if _DEBUG
-        Log(L"[%d]FindNextFileFixupV2 invaid handle.", FindNextFileInstance2);
+        Log(L"[%d] FindNextFileFixupV2 invaid handle.", FindNextFileInstance2);
 #endif
         ::SetLastError(ERROR_INVALID_PARAMETER);
         return FALSE;
@@ -619,11 +619,11 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
     auto data = reinterpret_cast<find_data2*>(findFile);
 
 #if _DEBUG
-    //Log(L"[%d][%d]FindNextFileFixupV2 is against redir    =%ls", data->RememberedInstance, FindNextFileInstance2, data->redirect_path.c_str());
-    //Log(L"[%d][%d]FindNextFileFixupV2 is against pkgVfs   =%ls", data->RememberedInstance, FindNextFileInstance2, data->package_vfs_path.c_str());
-    Log(L"[%d][%d]FindNextFileFixupV2 is against original request=%ls", data->RememberedInstance, FindNextFileInstance2, data->requested_path.c_str());
-    //Log(L[%d]"[%d]FindNextFileFixupV2 is against deVfs    =%ls", data->RememberedInstance, FindNextFileInstance2, data->package_devfs_path.c_str());
-    //Log(L"[%d][%d]FindNextFileFixupV2 is against deRedir  =%ls", data->RememberedInstance, FindNextFileInstance2, data->package_deredirect_path.c_str());
+    //Log(L"[%d][%d] FindNextFileFixupV2 is against redir    =%ls", data->RememberedInstance, FindNextFileInstance2, data->redirect_path.c_str());
+    //Log(L"[%d][%d] FindNextFileFixupV2 is against pkgVfs   =%ls", data->RememberedInstance, FindNextFileInstance2, data->package_vfs_path.c_str());
+    Log(L"[%d][%d] FindNextFileFixupV2 is against original request=%ls", data->RememberedInstance, FindNextFileInstance2, data->requested_path.c_str());
+    //Log(L[%d]"[%d] FindNextFileFixupV2 is against deVfs    =%ls", data->RememberedInstance, FindNextFileInstance2, data->package_devfs_path.c_str());
+    //Log(L"[%d][%d] FindNextFileFixupV2 is against deRedir  =%ls", data->RememberedInstance, FindNextFileInstance2, data->package_deredirect_path.c_str());
 #endif
 
 #ifdef OBSOLETE
@@ -760,13 +760,13 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
     auto wasFileAlreadyProvided = [&](std::wstring findrequest, auto filename)
     {
 #if _DEBUG
-        LogString(FindNextFileInstance2, L"\tFindNextFileV2 wasFileAlreadyProvided versus", filename);
+        LogString(data->RememberedInstance, FindNextFileInstance2, L"\tFindNextFileV2 wasFileAlreadyProvided versus ",  filename);
 #endif
 
         if (data->already_returned_list.empty())
         {
 #if _DEBUG
-            Log(L"[%d]\tFindNextFileV2 wasFileAlreadyProvided returns false.", FindNextFileInstance2);
+            Log(L"[%d][%d]\tFindNextFileV2 wasFileAlreadyProvided returns false.", data->RememberedInstance, FindNextFileInstance2);
 #endif
             return false;
         }
@@ -839,18 +839,18 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
     {
         if (data->find_handles[0])
         {
-            //Log(L"[%d]FindNextFileV2[0] to be checked.", FindNextFileInstance2);
+            //Log(L"[%d] FindNextFileV2[0] to be checked.", FindNextFileInstance2);
             if (impl::FindNextFile(data->find_handles[0].get(), findFileData))
             {
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[0] returns TRUE: %ls", data->RememberedInstance, FindNextFileInstance2, widen(findFileData->cFileName).c_str());
+                Log(L"[%d][%d] FindNextFileV2[0] returns TRUE: %ls", data->RememberedInstance, FindNextFileInstance2, widen(findFileData->cFileName).c_str());
 #endif
                 data->already_returned_list.push_back(widen(findFileData->cFileName));
                 return TRUE;
             }
             else if (::GetLastError() == ERROR_NO_MORE_FILES)
             {
-                ///Log(L"[%d][%d]FindNextFileV2[0] had FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
+                ///Log(L"[%d][%d] FindNextFileV2[0] had FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
                 data->find_handles[0].reset();
                 ::SetLastError(ERROR_NO_MORE_FILES);
                 // now check[1]
@@ -859,7 +859,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             {
                 // Error due to something other than reaching the end 
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[0] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
+                Log(L"[%d][%d] FindNextFileV2[0] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
 #endif
                 return FALSE;
             }
@@ -892,7 +892,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             }
             else if (::GetLastError() == ERROR_NO_MORE_FILES)
             {
-                ///Log(L"[%d][%d]FindNextFileV2[1] had FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
+                ///Log(L"[%d][%d] FindNextFileV2[1] had FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
                 data->find_handles[1].reset();
                 ::SetLastError(ERROR_NO_MORE_FILES);
                 // now check [2]
@@ -900,7 +900,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             else
             {
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[1] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
+                Log(L"[%d][%d] FindNextFileV2[1] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
 #endif
                 // Error due to something other than reaching the end
                 return FALSE;
@@ -943,7 +943,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             }
             else if (::GetLastError() == ERROR_NO_MORE_FILES)
             {
-                ///Log(L"[%d][%d]FindNextFileV2[2] had FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
+                ///Log(L"[%d][%d] FindNextFileV2[2] had FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
                 data->find_handles[2].reset();
                 ::SetLastError(ERROR_NO_MORE_FILES);
                 ///now check [3]
@@ -951,7 +951,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             else
             {
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[2] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
+                Log(L"[%d][%d] FindNextFileV2[2] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
 #endif
                 // Error due to something other than reaching the end
                 return FALSE;
@@ -987,7 +987,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             else if (::GetLastError() == ERROR_NO_MORE_FILES)
             {
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[3] returns FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
+                Log(L"[%d][%d] FindNextFileV2[3] returns FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
 #endif
                 data->find_handles[3].reset();
                 ::SetLastError(ERROR_NO_MORE_FILES);
@@ -996,7 +996,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             else
             {
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[3] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
+                Log(L"[%d][%d] FindNextFileV2[3] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
 #endif
                 // Error due to something other than reaching the end
                 // return existing error code
@@ -1033,7 +1033,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             else if (::GetLastError() == ERROR_NO_MORE_FILES)
             {
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[4] returns FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
+                Log(L"[%d][%d] FindNextFileV2[4] returns FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
 #endif
                 data->find_handles[4].reset();
                 ::SetLastError(ERROR_NO_MORE_FILES);
@@ -1042,7 +1042,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
             else
             {
 #if _DEBUG
-                Log(L"[%d][%d]FindNextFileV2[4] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
+                Log(L"[%d][%d] FindNextFileV2[4] returns FALSE 0x%x", data->RememberedInstance, FindNextFileInstance2, ::GetLastError());
 #endif
                 // Error due to something other than reaching the end
                 // return existing error code
@@ -1054,7 +1054,7 @@ BOOL __stdcall FindNextFileFixupV2(_In_ HANDLE findFile, _Out_ win32_find_data_t
 
     // We ran out of data either on a previous call, or by ignoring files that have been redirected
 #if _DEBUG
-    Log(L"[%d][%d]FindNextFileV2 returns FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
+    Log(L"[%d][%d] FindNextFileV2 returns FALSE with ERROR_NO_MORE_FILES.", data->RememberedInstance, FindNextFileInstance2);
 #endif
     ::SetLastError(ERROR_NO_MORE_FILES);
     return FALSE;
@@ -1089,7 +1089,7 @@ BOOL __stdcall FindCloseFixupV2(_Inout_ HANDLE findHandle) noexcept
 
 #if _DEBUG
     auto data = reinterpret_cast<find_data2*>(findHandle);
-    Log(L"[%d][%d]FindCloseFixupV2.", data->RememberedInstance, FindCloseInstance);
+    Log(L"[%d][%d] FindCloseFixupV2.", data->RememberedInstance, FindCloseInstance);
 #endif
 
     delete reinterpret_cast<find_data2*>(findHandle);

--- a/fixups/FileRedirectionFixup/PathRedirection.cpp
+++ b/fixups/FileRedirectionFixup/PathRedirection.cpp
@@ -23,7 +23,7 @@
 
 
 #if _DEBUG
-#define MOREDEBUG 1
+//#define MOREDEBUG 1
 #endif
 
 TRACELOGGING_DECLARE_PROVIDER(g_Log_ETW_ComponentProvider);
@@ -268,13 +268,22 @@ void InitializeConfiguration()
 {
     TraceLoggingRegister(g_Log_ETW_ComponentProvider);
     std::wstringstream traceDataStream;
+#if MOREDEBUG
+    Log("\t\tFRF CONFIG: Look for config");
+#endif            
 
     if (auto rootConfig = ::PSFQueryCurrentDllConfig())
     {
+#if MOREDEBUG
+        Log("\t\tFRF CONFIG: Has config");
+#endif            
         auto& rootObject = rootConfig->as_object();
         traceDataStream << " config:\n";
         if (auto pathsValue = rootObject.try_get("redirectedPaths"))
         {
+#if MOREDEBUG
+            Log("\t\tFRF CONFIG: Has redirectedPaths");
+#endif            
             traceDataStream << " redirectedPaths:\n";
             auto& redirectedPathsObject = pathsValue->as_object();
             auto initializeRedirection = [&traceDataStream](const std::filesystem::path & basePath, const psf::json_array & specs, bool traceOnly = false)
@@ -326,18 +335,27 @@ void InitializeConfiguration()
 
             if (auto packageRelativeValue = redirectedPathsObject.try_get("packageRelative"))
             {
+#if MOREDEBUG
+                Log("\t\tFRF CONFIG: Has packageRelative");
+#endif 
                 traceDataStream << " packageRelative:\n";
                 initializeRedirection(g_packageRootPath, packageRelativeValue->as_array());
             }
 
             if (auto packageDriveRelativeValue = redirectedPathsObject.try_get("packageDriveRelative"))
             {
+#if MOREDEBUG
+                Log("\t\tFRF CONFIG: Has packageDriveRelative");
+#endif 
                 traceDataStream << " packageDriveRelative:\n";
                 initializeRedirection(g_packageRootPath.root_name(), packageDriveRelativeValue->as_array());
             }
 
             if (auto knownFoldersValue = redirectedPathsObject.try_get("knownFolders"))
             {
+#if MOREDEBUG
+                Log("\t\tFRF CONFIG: Has knownFolders");
+#endif 
                 traceDataStream << " knownFolders:\n";
                 for (auto& knownFolderValue : knownFoldersValue->as_array())
                 {

--- a/fixups/FileRedirectionFixup/PathRedirectionV2.cpp
+++ b/fixups/FileRedirectionFixup/PathRedirectionV2.cpp
@@ -24,7 +24,7 @@
 
 
 #if _DEBUG
-#define MOREDEBUG 1
+//#define MOREDEBUG 1
 #endif
 
 using namespace std::literals;
@@ -608,12 +608,12 @@ static path_redirect_info ShouldRedirectV2Impl(const CharT* path, redirect_flags
         for (auto& redirectSpec : g_redirectionSpecs)
         {
 #ifdef MOREDEBUG
-            //LogString(inst, L"\t\tFRFShouldRedirect: Check against: base", redirectSpec.base_path.c_str());
+            LogString(inst, L"\t\tFRFShouldRedirect: Check against: base", redirectSpec.base_path.c_str());
 #endif
             if (path_relative_to(pathVirtualizedV2.c_str(), redirectSpec.base_path))
             {
 #ifdef MOREDEBUG
-                //LogString(inst, L"\t\tFRFShouldRedirect: In ball park of base", redirectSpec.base_path.c_str());
+                LogString(inst, L"\t\tFRFShouldRedirect: In ball park of base", redirectSpec.base_path.c_str());
 #endif
                 auto relativePath = pathVirtualizedV2.c_str() + redirectSpec.base_path.native().length();
                 if (psf::is_path_separator(relativePath[0]))
@@ -628,7 +628,7 @@ static path_redirect_info ShouldRedirectV2Impl(const CharT* path, redirect_flags
                 // Otherwise exact match. Assume an implicit directory separator at the end (e.g. for matches to satisfy the
                 // first call to CreateDirectory
 #ifdef MOREDEBUG
-            //LogString(inst, L"\t\t\tFRFShouldRedirect: relativePath",relativePath);
+                LogString(inst, L"\t\t\tFRFShouldRedirect: relativePath",relativePath);
 #endif
                 if (std::regex_match(relativePath, redirectSpec.pattern))
                 {
@@ -655,8 +655,8 @@ static path_redirect_info ShouldRedirectV2Impl(const CharT* path, redirect_flags
                             destinationTargetBase = redirectSpec.redirect_targetbase;
 
 #ifdef MOREDEBUG
-                            //LogString(inst, L"\t\tFRFShouldRedirect isWide for", pathVirtualizedV2.c_str());
-                            //LogString(inst, L"\t\tFRFShouldRedirect isWide redir", destinationTargetBase.c_str());
+                            LogString(inst, L"\t\tFRFShouldRedirect isWide for", pathVirtualizedV2.c_str());
+                            LogString(inst, L"\t\tFRFShouldRedirect isWide redir", destinationTargetBase.c_str());
 #endif
                             result.redirect_path = RedirectedPathV2(vfspathV2, flag_set(flags, redirect_flags::ensure_directory_structure), destinationTargetBase, inst);
 
@@ -732,14 +732,14 @@ static path_redirect_info ShouldRedirectV2Impl(const CharT* path, redirect_flags
                 else
                 {
 #ifdef MOREDEBUG
-                    //LogString(inst, L"\t\tFRFShouldRedirectV2: no match on parse relativePath", relativePath);
+                    LogString(inst, L"\t\tFRFShouldRedirectV2: no match on parse relativePath", relativePath);
 #endif
                 }
             }
             else
             {
 #ifdef MOREDEBUG
-                //LogString(inst, L"\t\tFRFShouldRedirectV2: Not in ball park of base", redirectSpec.base_path.c_str());
+                LogString(inst, L"\t\tFRFShouldRedirectV2: Not in ball park of base", redirectSpec.base_path.c_str());
 #endif
             }
         }

--- a/fixups/FileRedirectionFixup/readme.md
+++ b/fixups/FileRedirectionFixup/readme.md
@@ -9,6 +9,14 @@ When injected into a process, the File Redirection Fixup supports the ability to
 > > * In the case of a folder the redirected folder is created (including folder structures as needed) and used.
 > * The rule may optionally have additional configuration to modify the behavior, such as to control the redirected location or exempt a file from redirection.
 
+### Detecting the need for this fixup
+A static analysis of the files in the package is often all that is needed:
+> * If the package contains files in the VFS/AppData or VFS\LocalAppData folders that are required.
+> * If the package contains any files that might be updated.
+> * If the application wants to add new files to folders within the package.
+
+At runtime this can sometimes be detected as ACCESS_DENIED results to file operations, however File and Path not found may also indicate the need.
+
 ## About Debugging this fixup
 The Release build of this fixup produces no output to the debug console port for performance reasons.
 Use of the Debug build will enable you to see the intercepts and what the fixup did.

--- a/fixups/RegLegacyFixups/RegLegacyFixups.vcxproj
+++ b/fixups/RegLegacyFixups/RegLegacyFixups.vcxproj
@@ -23,14 +23,14 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{1d26cbd7-b670-4f8e-bbd8-4771b76c9215}</ProjectGuid>
     <RootNamespace>RegLegacyFixups</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -39,14 +39,14 @@
     <WholeProgramOptimization>
     </WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Static</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -55,7 +55,7 @@
     <WholeProgramOptimization>
     </WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Static</UseOfMfc>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/fixups/RegLegacyFixups/readme.md
+++ b/fixups/RegLegacyFixups/readme.md
@@ -1,8 +1,19 @@
 # Registry Legacy Fixups
 When injected into a process, RegLegacyFixups supports the ability to:
-> * Modifies certain registry calls that do not work due to the MSIX container restrictions by modifying the call parameters to a form that would be allowed.
+> * Modify certain registry calls that do not work due to the MSIX container restrictions by modifying the call parameters to a form that would be allowed.
 
 There is no guarantee that these changes will be enough to allow the application to perform properly, but often the change can solve application compatibility issues by removing request incompatible parameters that the application did not need.
+The fixup is generally considered safe to apply with common rules as shown in the example below, even for apps where it is not needed.
+
+### Detecting the need for this fixup
+For the IT Pro without access to the application source code, it is not possible to detect the need for this fixup by static analysis; the need must be determined by testing.
+This is generally easy to determine by running the application in the container with a tracing tool, either TraceFixup or Process Monitor trace.
+The application needing this fixup will experience ACCESS_DENIED results on registry operations. Most common are denials when the application attempts to open a registry key.  
+Less often seen is ACCESS_DENIED when the applicatoin tries to delete an item from the conrainter registry.
+
+For the developer, you should address the code making such calls directly instead of fixing with this fixup.  
+In the first case, you should now open registry keys with either the exact permissionis that you need, or MAX_ALLOWED.
+In all cases you should check and gracefully handle any error conditions you get.
 
 ## About Debugging this fixup
 The Release build of this fixup produces no output to the debug console port for performance reasons.
@@ -10,17 +21,7 @@ Use of the Debug build will enable you to see the intercepts and what the fixup 
 That output is easily seen using the Sysinternals "DebugView" tool.
 
 ### Dependencies for RegLegacyFixups
-The following dlls are also required and should generally be placed in the same folder as RegLegacyFixups:
-
-| Build | File | Source |
-| ----- | ---- | ------ |
-| Release | msvcp140.dll | VC141 |
-| Release | vcruntime140.dll | VC141 |
-| Debug | msvcp140d.dll | VC141 |
-| Debug | vcruntime140d.dll | VC141 |
-| Either  | ucrtbased.dll | SDK 10.0.17763 |
-
-Copies of these dlls are available in this project.
+Specific dependencies for this fixup have been removed.
 
 
 # General Configuration

--- a/include/psf_logging.h
+++ b/include/psf_logging.h
@@ -39,6 +39,9 @@ void LogString(DWORD inst, const wchar_t* name, const wchar_t* value);
 
 void LogStringWA(DWORD inst, const wchar_t* name, const char* value);
 void LogStringWW(DWORD inst, const wchar_t* name, const wchar_t* value);
+void LogString(DWORD rememberedInst, DWORD inst, const wchar_t* name, const char* value);
+
+void LogString(DWORD rememberedInst, DWORD inst, const wchar_t* name, const wchar_t* value);
 
 void LogCountedStringW(const char* name, const wchar_t* value, std::size_t length);
 

--- a/tests/fixups/CompositionTestFixup/CompositionTestFixup.vcxproj
+++ b/tests/fixups/CompositionTestFixup/CompositionTestFixup.vcxproj
@@ -30,23 +30,23 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{D823682D-A4F6-4F4E-A2BB-D1E28BCC06F5}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\Fixups.props" />

--- a/tests/fixups/MultiByteToWideCharTestFixup/MultiByteToWideCharTestFixup.vcxproj
+++ b/tests/fixups/MultiByteToWideCharTestFixup/MultiByteToWideCharTestFixup.vcxproj
@@ -30,23 +30,23 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{0C1F7A43-65DE-4460-A9EB-F44F40AF0968}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\Fixups.props" />

--- a/tests/fixups/TraceFixup/TraceFixup.vcxproj
+++ b/tests/fixups/TraceFixup/TraceFixup.vcxproj
@@ -47,23 +47,23 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{42E2CC9E-D708-4C4B-A91B-00B23F893C4C}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\Fixups.props" />

--- a/tests/fixups/WaitForDebuggerFixup/WaitForDebuggerFixup.vcxproj
+++ b/tests/fixups/WaitForDebuggerFixup/WaitForDebuggerFixup.vcxproj
@@ -34,23 +34,23 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{76053BA2-AB6B-4F27-90E1-EE5BFE2EFA70}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <SubSystem>Windows</SubSystem>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\Fixups.props" />


### PR DESCRIPTION
This fix itself should be non-breaking, but allows someone adding PsfLauncher to a package to optionally add an external manifest file to PsfLauncher.  If the target executable needs elevation, this elevation needs to be performed in PsfLauncher in order for the target to launch elevated inside the container with the dll injections.  See the Psflauncher readme for more details.