### PR TITLE
2023-6-3 Fix PsfRuntime injection for mixed bitness by PsfTooling style

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -9,6 +9,10 @@ ideas:
 	   for non-mapped native folders.
 *  SPC seems to immedietly fail PsfLauncher if Ilv is set in package.
  
+ v.next
+ * PsfRuntime: Fix issue with mixed bit processes and injection of PsfRuntime into new process when the Psf components are not located in the 
+   root folder of the package (i.e. PsfTooling was used).
+
  v.2023.02.05
  * MFR: Add UserProgramFiles to the VFS Traditional mappings.
  * MFR: Fix IsCreateForChange to consider FILE_ALL_ACCESS before BACKUP_SEMANTICS.

--- a/PsfRuntime/CreateProcessAsUser.cpp
+++ b/PsfRuntime/CreateProcessAsUser.cpp
@@ -669,7 +669,7 @@ BOOL WINAPI CreateProcessAsUserFixup(
         if (g_PsfRunTimeModulePath[0] != 0x0)
         {
             std::filesystem::path RuntimePath = g_PsfRunTimeModulePath;
-            pathToPsfRuntime = RuntimePath.string();
+            pathToPsfRuntime = (RuntimePath.parent_path() / wtargetDllName.c_str()).string();
         }
         else
         {

--- a/PsfRuntime/CreateProcessHook.cpp
+++ b/PsfRuntime/CreateProcessHook.cpp
@@ -1047,12 +1047,11 @@ BOOL WINAPI CreateProcessFixup(
 #if _DEBUG
         Log(L"\t[%d] CreateProcessFixup: Use runtime %ls", CreateProcessInstance, wtargetDllName.c_str());
 #endif
-        ///static const auto pathToPsfRuntime = (PackageRootPath() / wtargetDllName.c_str()).string();
         static std::string pathToPsfRuntime;
         if (g_PsfRunTimeModulePath[0] != 0x0)
         {
             std::filesystem::path RuntimePath = g_PsfRunTimeModulePath;
-            pathToPsfRuntime = RuntimePath.string();
+            pathToPsfRuntime = (RuntimePath.parent_path() / wtargetDllName.c_str()).string();
         }
         else
         {


### PR DESCRIPTION
Fix for injection of PsfRuntime into a new process when processes are of different bitnesses and the PSF components are not stored at the package root.  This happens with PsfTooling copies the PSF into app folders prior to there being a package..