### PR TITLE
Fix local traditional mapping not taking effect

### DIFF
--- a/fixups/MFRFixup/InitializeConfiguration.cpp
+++ b/fixups/MFRFixup/InitializeConfiguration.cpp
@@ -156,7 +156,9 @@ void InitializeConfiguration()
 #if MOREDEBUG
                                Log(L"\t\t\tTraditioal: %s", folderid.c_str());
 #endif
-                               map.Valid_mapping = false;
+                               mfr::mfr_folder_mapping newMap = mfr::CloneFolderMapping(map);
+                               newMap.Valid_mapping = false;
+                               mfr::g_MfrFolderMappings[MapIndex] = newMap;
                            }
                            else if (std::equal(mode.begin(), mode.end(), L"default", psf::path_compare{}))
                            {


### PR DESCRIPTION
Hi there!

I have an app with all of the local redirections set to "traditional" to make sure all app state gets persisted in the same central location. 

The app still ended up writing some files to the real Documents folder for some reason, so I dug into the code and came up with this change that seems to redirect those files into VFS/Profile/Documents in my local build.

That still doesn't feel quite right since I'd assume it would redirect to VFS/Personal directly judging from the description in the readme, whereas in this case, it seems to be disabling the rule completely and the redirection only happens because of the Profile traditional redirect.

That said, the current behavior still works for me, and I didn't want to make any more drastic changes without consulting with you first. 

Let me know whether this behavior is expected, happy to make any changes you'd like to see to get it merged. Cheers!