### PR TITLE
Fix FindFirstFileFixup wildcard handling

### DIFF
--- a/fixups/MFRFixup/DetermineCohorts.cpp
+++ b/fixups/MFRFixup/DetermineCohorts.cpp
@@ -372,10 +372,6 @@ void DetermineCohorts(std::wstring requestedPath, Cohorts *cohorts, bool UseMore
         {
             Log(L"[%s%d] %s: DetermineCohorts: Request is in_redirection_area_other.", g_MfrModuleName, dllInstance, FixupName);
         }
-        cohorts->WsRedirected = cohorts->WsRequested;
-        cohorts->WsPackage = cohorts->WsRequested;
-        cohorts->WsNative = cohorts->WsRequested;
-        cohorts->map = mfr::MakeInvalidMapping();
         cohorts->UsingNative = false;
         break;
     case mfr::mfr_path_types::is_Protocol:
@@ -390,10 +386,6 @@ void DetermineCohorts(std::wstring requestedPath, Cohorts *cohorts, bool UseMore
         {
             Log(L"[%s%d] %s: DetermineCohorts: Request is in_non_redirectable_areas.", g_MfrModuleName, dllInstance, FixupName);
         }
-        cohorts->map = mfr::MakeInvalidMapping();
-        cohorts->WsRedirected = cohorts->WsRequested;
-        cohorts->WsPackage = cohorts->WsRequested;
-        cohorts->WsNative = cohorts->WsRequested;
         cohorts->UsingNative = false;
         break;
     }

--- a/fixups/MFRFixup/DetermineCohorts.cpp
+++ b/fixups/MFRFixup/DetermineCohorts.cpp
@@ -372,6 +372,10 @@ void DetermineCohorts(std::wstring requestedPath, Cohorts *cohorts, bool UseMore
         {
             Log(L"[%s%d] %s: DetermineCohorts: Request is in_redirection_area_other.", g_MfrModuleName, dllInstance, FixupName);
         }
+        cohorts->WsRedirected = cohorts->WsRequested;
+        cohorts->WsPackage = cohorts->WsRequested;
+        cohorts->WsNative = cohorts->WsRequested;
+        cohorts->map = mfr::MakeInvalidMapping();
         cohorts->UsingNative = false;
         break;
     case mfr::mfr_path_types::is_Protocol:
@@ -386,6 +390,10 @@ void DetermineCohorts(std::wstring requestedPath, Cohorts *cohorts, bool UseMore
         {
             Log(L"[%s%d] %s: DetermineCohorts: Request is in_non_redirectable_areas.", g_MfrModuleName, dllInstance, FixupName);
         }
+        cohorts->map = mfr::MakeInvalidMapping();
+        cohorts->WsRedirected = cohorts->WsRequested;
+        cohorts->WsPackage = cohorts->WsRequested;
+        cohorts->WsNative = cohorts->WsRequested;
         cohorts->UsingNative = false;
         break;
     }

--- a/fixups/MFRFixup/InitializeMFRFixup.cpp
+++ b/fixups/MFRFixup/InitializeMFRFixup.cpp
@@ -92,7 +92,18 @@ void InitializeMFRFixup()
     catch (...)
     {
 #ifdef _DEBUG
-        Log("[%s%d]\t\tMfrFixup ignorable exception creating directories.", g_MfrModuleName, 0);
+        Log("[%s%d]\t\tMfrFixup ignorable exception creating WritablePackageRoot directories.", g_MfrModuleName, 0);
+#endif
+    }
+
+    try
+    {
+        std::filesystem::create_directories(g_writablePackageRootPath / L"VFS");
+    }
+    catch (...)
+    {
+#ifdef _DEBUG
+        Log("[%s%d]\t\tMfrFixup ignorable exception creating VFS directories.", g_MfrModuleName, 0);
 #endif
     }
 

--- a/fixups/MFRFixup/ManagedPathTypes.cpp
+++ b/fixups/MFRFixup/ManagedPathTypes.cpp
@@ -49,7 +49,7 @@ namespace mfr
 
     mfr_path_types Get_ManagedPathTypeForDriveAbsolute(std::filesystem::path path)
     {
-        std::filesystem::path forwardPath = path.generic_string();  // get rid of "/" issue by changing all "\\" to "/" for the comparison.
+        std::filesystem::path forwardPath = path.generic_wstring();  // get rid of "/" issue by changing all "\\" to "/" for the comparison.
         //if (pathString_isSubsetOf_Path(g_writablePackageRootPath.generic_wstring().c_str(), path))
         if (pathString_isSubsetOf_Path(g_writablePackageRootPath.generic_wstring().c_str(), forwardPath))
         {
@@ -96,9 +96,7 @@ namespace mfr
 
         //Log(L"[%s%d] FID_RootDrive  %s", g_MfrModuleName, dllInstance, FID_RootDrive.generic_wstring().c_str());
         //if (!pathString_isSubsetOf_Path(FID_RootDrive.generic_wstring().c_str(), path))
-        std::wstring rootDriveLower = FID_RootDrive.generic_wstring();
-        std::transform(rootDriveLower.begin(), rootDriveLower.end(), rootDriveLower.begin(), std::towlower);
-        if (!pathString_isSubsetOf_Path(rootDriveLower.c_str(), forwardPath))
+        if (!pathString_isSubsetOf_Path(FID_RootDrive.generic_wstring().c_str(), forwardPath))
         {
             return mfr_path_types::in_other_drive_area;
         }

--- a/fixups/MFRFixup/ManagedPathTypes.cpp
+++ b/fixups/MFRFixup/ManagedPathTypes.cpp
@@ -7,6 +7,8 @@
 #include "FID.h"
 #include "PathUtilities.h"
 #include <psf_logging.h>
+#include <algorithm>
+#include <cctype>
 
 namespace mfr
 {
@@ -94,7 +96,9 @@ namespace mfr
 
         //Log(L"[%s%d] FID_RootDrive  %s", g_MfrModuleName, dllInstance, FID_RootDrive.generic_wstring().c_str());
         //if (!pathString_isSubsetOf_Path(FID_RootDrive.generic_wstring().c_str(), path))
-        if (!pathString_isSubsetOf_Path(FID_RootDrive.generic_wstring().c_str(), forwardPath))
+        std::wstring rootDriveLower = FID_RootDrive.generic_wstring();
+        std::transform(rootDriveLower.begin(), rootDriveLower.end(), rootDriveLower.begin(), std::towlower);
+        if (!pathString_isSubsetOf_Path(rootDriveLower.c_str(), forwardPath))
         {
             return mfr_path_types::in_other_drive_area;
         }

--- a/fixups/MFRFixup/PathUtilities.cpp
+++ b/fixups/MFRFixup/PathUtilities.cpp
@@ -106,7 +106,7 @@ bool pathString_isExactMatchOf_Path(const char* pathstring, std::filesystem::pat
 /// </summary>
 bool pathString_isSubsetOf_Path(const wchar_t* pathstring, std::filesystem::path& Path)
 {
-    if (wcsncmp(pathstring, Path.wstring().c_str(), wcslen(pathstring)) == 0)  
+    if (_wcsnicmp(pathstring, Path.generic_wstring().c_str(), wcslen(pathstring)) == 0)  
     {
         return true;
     }
@@ -119,7 +119,7 @@ bool pathString_isSubsetOf_Path(const wchar_t* pathstring, std::filesystem::path
 }
 bool pathString_isSubsetOf_Path(const char* pathstring, std::filesystem::path& Path)
 {
-    if (strncmp(pathstring, Path.string().c_str(), strlen(pathstring)) == 0)
+    if (_strnicmp(pathstring, Path.generic_string().c_str(), strlen(pathstring)) == 0)
     {
         return true;
     }


### PR DESCRIPTION
Hi Tim, we recently updated to the latest available version (v2025.06.09), and discovered a possible bug/regression with the FindFirstFileFixup. Here are the relevant logs from debugview:

```
[27488] [M70005] FindFirstFileFixup: for fileName=.\*.*
[27488] [M70005] FindFirstFileFixup: DetermineCohorts: Request is in_non_redirectable_areas.
[27488] [M70005] FindFirstFileFixup: DetermineCohorts:   Cohort->WsRequested  c:\program files\windowsapps\redacted_0.0.0.6_x86__acnvdq3qnkfkr\app\.\*.*
[27488] [M70005] FindFirstFileFixup: DetermineCohorts:   Cohort->map.Valid_Mapping -858993460
[27488] [M70005] FindFirstFileFixup:  Adjusted Path=.\*.*
[27488] [M70005] FindFirstFileFixup:      RedirPath=
[27488] [M70005] FindFirstFileFixup:    PackagePath=
[27488] [M70005] FindFirstFileFixup:  NO NativePath
[27488] [M70006]  FindFirstFileExFixup: (unguarded) for fileName=
[27488] [M70006] FindFirstFileFixup returns 0xffffffff
[27488] [M70005] FindFirstFileFixup[0] (from redirected): no results.
[27488] [M70007]  FindFirstFileExFixup: (unguarded) for fileName=
[27488] [M70007] FindFirstFileFixup returns 0xffffffff
[27488] [M70005] FindFirstFileFixup[1] (from package):   no results.
[27488] [M70005] FindFirstFileFixup[2] (from native):    no results possible.
[27488] [M70005] FindFirstFileFixup returns 0x3
```

As you can see it seems to be having trouble handling a wildcard input when there are definitely files in that directory. I believe this may also be a regression since the same package used to work just fine with a custom build based on v2024.06.07.

I tried a few things with the help of ChatGPT Codex and the changes here seemed to do the trick, but I can't say I fully understand why. Here are the new debug logs:

```
[30552] [M70005] FindFirstFileFixup: for fileName=.\*.*
[30552] [M70005] FindFirstFileFixup: DetermineCohorts: Request is in_non_redirectable_areas.
[30552] [M70005] FindFirstFileFixup: DetermineCohorts:   Cohort->WsRequested  c:\program files\windowsapps\redacted_0.0.0.12_x86__acnvdq3qnkfkr\app\.\*.*
[30552] [M70005] FindFirstFileFixup: DetermineCohorts:   Cohort->map.Valid_Mapping 0
[30552] [M70005] FindFirstFileFixup:  Adjusted Path=c:\program files\windowsapps\redacted_0.0.0.12_x86__acnvdq3qnkfkr\app\.\*.*
[30552] [M70005] FindFirstFileFixup:      RedirPath=c:\program files\windowsapps\redacted_0.0.0.12_x86__acnvdq3qnkfkr\app\.\*.*
[30552] [M70005] FindFirstFileFixup:    PackagePath=c:\program files\windowsapps\redacted_0.0.0.12_x86__acnvdq3qnkfkr\app\.\*.*
[30552] [M70005] FindFirstFileFixup:  NO NativePath
[30552] [M70006]  FindFirstFileExFixup: (unguarded) for fileName=c:\program files\windowsapps\redacted_0.0.0.12_x86__acnvdq3qnkfkr\app\.\*.*
[30552] [M70006] FindFirstFileFixup returns 0xc85928
[30552] [M70005] FindFirstFileFixup[0] (from redirected): had results . 
[30552] [M70007]  FindFirstFileExFixup: (unguarded) for fileName=c:\program files\windowsapps\redacted_0.0.0.12_x86__acnvdq3qnkfkr\app\.\*.*
[30552] [M70007] FindFirstFileFixup returns 0xc86628
[30552] [M70005] FindFirstFileFixup[1] (from package):   had results . 
[30552] [M70005] FindFirstFileFixup[2] (from native):    no results possible.
[30552] [M70005] FindFirstFileFixup returns . 
```

Please feel free to close this PR and implement a different fix if you have a better idea of what the regression/root cause might be, happy to help test out any new builds you push out. Cheers!